### PR TITLE
Tabellen aan drop-tables toegevoegd, evenals rekening houden met e-trema in overigrelief

### DIFF
--- a/top10nl/bin/top10-drop-tables.sql
+++ b/top10nl/bin/top10-drop-tables.sql
@@ -1,28 +1,57 @@
-DROP TABLE IF EXISTS 	wegdeel_vlak;
-DROP TABLE IF EXISTS 	wegdeel_lijn;
-DROP TABLE IF EXISTS 	wegdeel_punt;
-DROP TABLE IF EXISTS 	wegdeel_hartlijn;
-DROP TABLE IF EXISTS 	wegdeel_hartpunt;
+DROP TABLE IF EXISTS	functioneelgebied;
 DROP TABLE IF EXISTS 	functioneelgebied_punt;
-DROP TABLE IF EXISTS 	gebouw_vlak;
-DROP TABLE IF EXISTS	terrein_vlak;
-DROP TABLE IF EXISTS	waterdeel_lijn;
-DROP TABLE IF EXISTS	waterdeel_vlak;
+DROP TABLE IF EXISTS 	functioneelgebied_vlak;
 
+DROP TABLE IF EXISTS	gebouw;
+DROP TABLE IF EXISTS 	gebouw_vlak;
+
+DROP TABLE IF EXISTS	geografischgebied;
 DROP TABLE IF EXISTS	geografischgebied_punt;
+DROP TABLE IF EXISTS	geografischgebied_vlak;
+
 DROP TABLE IF EXISTS	hoogteofdiepte_punt;
+DROP TABLE IF EXISTS	hoogteofdieptepunt;
+
+DROP TABLE IF EXISTS	hoogteverschil;
 DROP TABLE IF EXISTS	hoogteverschilhz_lijn;
 DROP TABLE IF EXISTS	hoogteverschillz_lijn;
+
+DROP TABLE IF EXISTS	inrichtingselement;
+DROP TABLE IF EXISTS	inrichtingselement_lijn;
+DROP TABLE IF EXISTS	inrichtingselement_punt;
+
+DROP TABLE IF EXISTS	isohoogte;
 DROP TABLE IF EXISTS	isohoogte_lijn;
+
+DROP TABLE IF EXISTS	kadeofwal;
 DROP TABLE IF EXISTS	kadeofwal_lijn;
+
+DROP TABLE IF EXISTS	"overigreliëf";
+DROP TABLE IF EXISTS	"overigreliëf_lijn";
+DROP TABLE IF EXISTS	"overigreliëf_punt";
+
+DROP TABLE IF EXISTS	registratiefgebied;
 DROP TABLE IF EXISTS	registratiefgebied_vlak;
+DROP TABLE IF EXISTS	registratiefgebied_punt;
+
+DROP TABLE IF EXISTS	spoorbaandeel;
 DROP TABLE IF EXISTS	spoorbaandeel_lijn;
 DROP TABLE IF EXISTS	spoorbaandeel_punt;
 
-DROP TABLE IF EXISTS	waterdeel;
-DROP TABLE IF EXISTS	wegdeel;
-DROP TABLE IF EXISTS	functioneelgebied;
-DROP TABLE IF EXISTS	gebouw;
 DROP TABLE IF EXISTS	terrein;
+DROP TABLE IF EXISTS	terrein_vlak;
+
+DROP TABLE IF EXISTS	waterdeel;
+DROP TABLE IF EXISTS	waterdeel_lijn;
+DROP TABLE IF EXISTS	waterdeel_punt;
+DROP TABLE IF EXISTS	waterdeel_vlak;
+
+DROP TABLE IF EXISTS	wegdeel;
+DROP TABLE IF EXISTS 	wegdeel_hartlijn;
+DROP TABLE IF EXISTS 	wegdeel_hartpunt;
+DROP TABLE IF EXISTS 	wegdeel_lijn;
+DROP TABLE IF EXISTS 	wegdeel_punt;
+DROP TABLE IF EXISTS 	wegdeel_vlak;
+
 DELETE FROM geometry_columns;
 

--- a/top10nl/bin/top10-split.xsl
+++ b/top10nl/bin/top10-split.xsl
@@ -100,7 +100,7 @@ simpelweg doorgeggeven.
              <xsl:call-template name="SplitsRegistratiefGebied"/>
          </xsl:for-each>
 
-        <xsl:for-each select="top10nl:OverigRelief">
+        <xsl:for-each select="top10nl:OverigReliëf">
                 <xsl:call-template name="SplitsOverigRelief"/>
             </xsl:for-each>
 
@@ -213,14 +213,14 @@ simpelweg doorgeggeven.
      <xsl:template name="SplitsOverigRelief">
           <xsl:if test="top10nl:geometrieLijn != ''">
               <xsl:call-template name="CopyWithSingleGeometry">
-                  <xsl:with-param name="objectType">OverigRelief_Lijn</xsl:with-param>
+                  <xsl:with-param name="objectType">OverigReliëf_Lijn</xsl:with-param>
                   <xsl:with-param name="geometrie" select="top10nl:geometrieLijn"/>
               </xsl:call-template>
           </xsl:if>
 
           <xsl:if test="top10nl:geometriePunt != ''">
               <xsl:call-template name="CopyWithSingleGeometry">
-                  <xsl:with-param name="objectType">OverigRelief_Punt</xsl:with-param>
+                  <xsl:with-param name="objectType">OverigReliëf_Punt</xsl:with-param>
                   <xsl:with-param name="geometrie" select="top10nl:geometriePunt"/>
               </xsl:call-template>
           </xsl:if>


### PR DESCRIPTION
Het bestand top10-drop-tables.sql was nog incompleet. Zowel alle originele als afgeleide Top10NL-tabellen waren niet aanwezig. Ik heb het bestand tevens gesorteerd. Ook het bestand top10-split.xsl is aangepast. Het featuretype OverigReliëf heeft namelijk een trema in de naam.

NB: bij het uitvoeren van het SQL script wordt verondersteld dat de console in codepage ISO-8859-1 (of Windows 1252 / Latin1) is. Hopelijk is dat geen bezwaar.
