### PR TITLE
Opsplitsen naam / straatnaam kolommen in Nederland en Fries

### DIFF
--- a/top10nl/bin/top10-gfs-template_split.xml
+++ b/top10nl/bin/top10-gfs-template_split.xml
@@ -39,8 +39,14 @@
       <Width>250</Width>
     </PropertyDefn>
     <PropertyDefn>
-      <Name>naam</Name>
-      <ElementPath>naam</ElementPath>
+      <Name>naamNL</Name>
+      <ElementPath>naamNL</ElementPath>
+      <Type>String</Type>
+      <Width>250</Width>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>naamFries</Name>
+      <ElementPath>naamFries</ElementPath>
       <Type>String</Type>
       <Width>250</Width>
     </PropertyDefn>
@@ -123,8 +129,14 @@
       <Width>250</Width>
     </PropertyDefn>
     <PropertyDefn>
-      <Name>naam</Name>
-      <ElementPath>naam</ElementPath>
+      <Name>naamNL</Name>
+      <ElementPath>naamNL</ElementPath>
+      <Type>String</Type>
+      <Width>250</Width>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>naamFries</Name>
+      <ElementPath>naamFries</ElementPath>
       <Type>String</Type>
       <Width>250</Width>
     </PropertyDefn>
@@ -207,8 +219,14 @@
       <Width>250</Width>
     </PropertyDefn>
     <PropertyDefn>
-      <Name>naam</Name>
-      <ElementPath>naam</ElementPath>
+      <Name>naamNL</Name>
+      <ElementPath>naamNL</ElementPath>
+      <Type>String</Type>
+      <Width>250</Width>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>naamFries</Name>
+      <ElementPath>naamFries</ElementPath>
       <Type>String</Type>
       <Width>250</Width>
     </PropertyDefn>
@@ -308,8 +326,14 @@
       <Width>250</Width>
     </PropertyDefn>
     <PropertyDefn>
-      <Name>naam</Name>
-      <ElementPath>naam</ElementPath>
+      <Name>naamNL</Name>
+      <ElementPath>naamNL</ElementPath>
+      <Type>String</Type>
+      <Width>250</Width>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>naamFries</Name>
+      <ElementPath>naamFries</ElementPath>
       <Type>String</Type>
       <Width>250</Width>
     </PropertyDefn>
@@ -398,8 +422,14 @@
       <Width>250</Width>
     </PropertyDefn>
     <PropertyDefn>
-      <Name>naam</Name>
-      <ElementPath>naam</ElementPath>
+      <Name>naamNL</Name>
+      <ElementPath>naamNL</ElementPath>
+      <Type>String</Type>
+      <Width>250</Width>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>naamFries</Name>
+      <ElementPath>naamFries</ElementPath>
       <Type>String</Type>
       <Width>250</Width>
     </PropertyDefn>
@@ -488,8 +518,14 @@
       <Width>250</Width>
     </PropertyDefn>
     <PropertyDefn>
-      <Name>naam</Name>
-      <ElementPath>naam</ElementPath>
+      <Name>naamNL</Name>
+      <ElementPath>naamNL</ElementPath>
+      <Type>String</Type>
+      <Width>250</Width>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>naamFries</Name>
+      <ElementPath>naamFries</ElementPath>
       <Type>String</Type>
       <Width>250</Width>
     </PropertyDefn>
@@ -596,8 +632,14 @@
       <Width>250</Width>
     </PropertyDefn>
     <PropertyDefn>
-      <Name>naam</Name>
-      <ElementPath>naam</ElementPath>
+      <Name>naamNL</Name>
+      <ElementPath>naamNL</ElementPath>
+      <Type>String</Type>
+      <Width>250</Width>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>naamFries</Name>
+      <ElementPath>naamFries</ElementPath>
       <Type>String</Type>
       <Width>250</Width>
     </PropertyDefn>
@@ -704,8 +746,14 @@
       <Width>250</Width>
     </PropertyDefn>
     <PropertyDefn>
-      <Name>naam</Name>
-      <ElementPath>naam</ElementPath>
+      <Name>naamNL</Name>
+      <ElementPath>naamNL</ElementPath>
+      <Type>String</Type>
+      <Width>250</Width>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>naamFries</Name>
+      <ElementPath>naamFries</ElementPath>
       <Type>String</Type>
       <Width>250</Width>
     </PropertyDefn>
@@ -812,8 +860,14 @@
       <Width>250</Width>
     </PropertyDefn>
     <PropertyDefn>
-      <Name>naam</Name>
-      <ElementPath>naam</ElementPath>
+      <Name>naamNL</Name>
+      <ElementPath>naamNL</ElementPath>
+      <Type>String</Type>
+      <Width>250</Width>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>naamFries</Name>
+      <ElementPath>naamFries</ElementPath>
       <Type>String</Type>
       <Width>250</Width>
     </PropertyDefn>
@@ -913,8 +967,14 @@
       <Width>250</Width>
     </PropertyDefn>
     <PropertyDefn>
-      <Name>naam</Name>
-      <ElementPath>naam</ElementPath>
+      <Name>naamNL</Name>
+      <ElementPath>naamNL</ElementPath>
+      <Type>String</Type>
+      <Width>250</Width>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>naamFries</Name>
+      <ElementPath>naamFries</ElementPath>
       <Type>String</Type>
       <Width>250</Width>
     </PropertyDefn>
@@ -1014,8 +1074,14 @@
       <Width>250</Width>
     </PropertyDefn>
     <PropertyDefn>
-      <Name>naam</Name>
-      <ElementPath>naam</ElementPath>
+      <Name>naamNL</Name>
+      <ElementPath>naamNL</ElementPath>
+      <Type>String</Type>
+      <Width>250</Width>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>naamFries</Name>
+      <ElementPath>naamFries</ElementPath>
       <Type>String</Type>
       <Width>250</Width>
     </PropertyDefn>
@@ -1122,8 +1188,14 @@
       <Width>250</Width>
     </PropertyDefn>
     <PropertyDefn>
-      <Name>naam</Name>
-      <ElementPath>naam</ElementPath>
+      <Name>naamNL</Name>
+      <ElementPath>naamNL</ElementPath>
+      <Type>String</Type>
+      <Width>250</Width>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>naamFries</Name>
+      <ElementPath>naamFries</ElementPath>
       <Type>String</Type>
       <Width>250</Width>
     </PropertyDefn>
@@ -1230,8 +1302,14 @@
       <Width>250</Width>
     </PropertyDefn>
     <PropertyDefn>
-      <Name>naam</Name>
-      <ElementPath>naam</ElementPath>
+      <Name>naamNL</Name>
+      <ElementPath>naamNL</ElementPath>
+      <Type>String</Type>
+      <Width>250</Width>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>naamFries</Name>
+      <ElementPath>naamFries</ElementPath>
       <Type>String</Type>
       <Width>250</Width>
     </PropertyDefn>
@@ -1338,8 +1416,14 @@
       <Width>250</Width>
     </PropertyDefn>
     <PropertyDefn>
-      <Name>naam</Name>
-      <ElementPath>naam</ElementPath>
+      <Name>naamNL</Name>
+      <ElementPath>naamNL</ElementPath>
+      <Type>String</Type>
+      <Width>250</Width>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>naamFries</Name>
+      <ElementPath>naamFries</ElementPath>
       <Type>String</Type>
       <Width>250</Width>
     </PropertyDefn>
@@ -1446,8 +1530,14 @@
       <Width>250</Width>
     </PropertyDefn>
     <PropertyDefn>
-      <Name>naam</Name>
-      <ElementPath>naam</ElementPath>
+      <Name>naamNL</Name>
+      <ElementPath>naamNL</ElementPath>
+      <Type>String</Type>
+      <Width>250</Width>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>naamFries</Name>
+      <ElementPath>naamFries</ElementPath>
       <Type>String</Type>
       <Width>250</Width>
     </PropertyDefn>
@@ -1536,8 +1626,14 @@
       <Width>250</Width>
     </PropertyDefn>
     <PropertyDefn>
-      <Name>naam</Name>
-      <ElementPath>naam</ElementPath>
+      <Name>naamNL</Name>
+      <ElementPath>naamNL</ElementPath>
+      <Type>String</Type>
+      <Width>250</Width>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>naamFries</Name>
+      <ElementPath>naamFries</ElementPath>
       <Type>String</Type>
       <Width>250</Width>
     </PropertyDefn>
@@ -1626,8 +1722,14 @@
       <Width>250</Width>
     </PropertyDefn>
     <PropertyDefn>
-      <Name>naam</Name>
-      <ElementPath>naam</ElementPath>
+      <Name>naamNL</Name>
+      <ElementPath>naamNL</ElementPath>
+      <Type>String</Type>
+      <Width>250</Width>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>naamFries</Name>
+      <ElementPath>naamFries</ElementPath>
       <Type>String</Type>
       <Width>250</Width>
     </PropertyDefn>
@@ -1769,8 +1871,14 @@
       <Width>250</Width>
     </PropertyDefn>
     <PropertyDefn>
-      <Name>naam</Name>
-      <ElementPath>naam</ElementPath>
+      <Name>naamNL</Name>
+      <ElementPath>naamNL</ElementPath>
+      <Type>String</Type>
+      <Width>250</Width>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>naamFries</Name>
+      <ElementPath>naamFries</ElementPath>
       <Type>String</Type>
       <Width>250</Width>
     </PropertyDefn>
@@ -1912,8 +2020,14 @@
       <Width>250</Width>
     </PropertyDefn>
     <PropertyDefn>
-      <Name>naam</Name>
-      <ElementPath>naam</ElementPath>
+      <Name>naamNL</Name>
+      <ElementPath>naamNL</ElementPath>
+      <Type>String</Type>
+      <Width>250</Width>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>naamFries</Name>
+      <ElementPath>naamFries</ElementPath>
       <Type>String</Type>
       <Width>250</Width>
     </PropertyDefn>
@@ -2013,8 +2127,14 @@
       <Width>250</Width>
     </PropertyDefn>
     <PropertyDefn>
-      <Name>naam</Name>
-      <ElementPath>naam</ElementPath>
+      <Name>naamNL</Name>
+      <ElementPath>naamNL</ElementPath>
+      <Type>String</Type>
+      <Width>250</Width>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>naamFries</Name>
+      <ElementPath>naamFries</ElementPath>
       <Type>String</Type>
       <Width>250</Width>
     </PropertyDefn>
@@ -2168,8 +2288,14 @@
       <Width>250</Width>
     </PropertyDefn>
     <PropertyDefn>
-      <Name>naam</Name>
-      <ElementPath>naam</ElementPath>
+      <Name>naamNL</Name>
+      <ElementPath>naamNL</ElementPath>
+      <Type>String</Type>
+      <Width>250</Width>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>naamFries</Name>
+      <ElementPath>naamFries</ElementPath>
       <Type>String</Type>
       <Width>250</Width>
     </PropertyDefn>
@@ -2323,8 +2449,14 @@
       <Width>250</Width>
     </PropertyDefn>
     <PropertyDefn>
-      <Name>naam</Name>
-      <ElementPath>naam</ElementPath>
+      <Name>naamNL</Name>
+      <ElementPath>naamNL</ElementPath>
+      <Type>String</Type>
+      <Width>250</Width>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>naamFries</Name>
+      <ElementPath>naamFries</ElementPath>
       <Type>String</Type>
       <Width>250</Width>
     </PropertyDefn>
@@ -2478,8 +2610,14 @@
       <Width>250</Width>
     </PropertyDefn>
     <PropertyDefn>
-      <Name>naam</Name>
-      <ElementPath>naam</ElementPath>
+      <Name>naamNL</Name>
+      <ElementPath>naamNL</ElementPath>
+      <Type>String</Type>
+      <Width>250</Width>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>naamFries</Name>
+      <ElementPath>naamFries</ElementPath>
       <Type>String</Type>
       <Width>250</Width>
     </PropertyDefn>
@@ -2675,8 +2813,14 @@
       <Width>250</Width>
     </PropertyDefn>
     <PropertyDefn>
-      <Name>naam</Name>
-      <ElementPath>naam</ElementPath>
+      <Name>naamNL</Name>
+      <ElementPath>naamNL</ElementPath>
+      <Type>String</Type>
+      <Width>250</Width>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>naamFries</Name>
+      <ElementPath>naamFries</ElementPath>
       <Type>String</Type>
       <Width>250</Width>
     </PropertyDefn>
@@ -2735,8 +2879,14 @@
       <Type>Integer</Type>
     </PropertyDefn>
     <PropertyDefn>
-      <Name>straatnaam</Name>
-      <ElementPath>straatnaam</ElementPath>
+      <Name>straatnaamNL</Name>
+      <ElementPath>straatnaamNL</ElementPath>
+      <Type>String</Type>
+      <Width>250</Width>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>straatnaamFries</Name>
+      <ElementPath>straatnaamFries</ElementPath>
       <Type>String</Type>
       <Width>250</Width>
     </PropertyDefn>
@@ -2872,8 +3022,14 @@
       <Width>250</Width>
     </PropertyDefn>
     <PropertyDefn>
-      <Name>naam</Name>
-      <ElementPath>naam</ElementPath>
+      <Name>naamNL</Name>
+      <ElementPath>naamNL</ElementPath>
+      <Type>String</Type>
+      <Width>250</Width>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>naamFries</Name>
+      <ElementPath>naamFries</ElementPath>
       <Type>String</Type>
       <Width>250</Width>
     </PropertyDefn>
@@ -3069,8 +3225,14 @@
       <Width>250</Width>
     </PropertyDefn>
     <PropertyDefn>
-      <Name>naam</Name>
-      <ElementPath>naam</ElementPath>
+      <Name>naamNL</Name>
+      <ElementPath>naamNL</ElementPath>
+      <Type>String</Type>
+      <Width>250</Width>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>naamFries</Name>
+      <ElementPath>naamFries</ElementPath>
       <Type>String</Type>
       <Width>250</Width>
     </PropertyDefn>
@@ -3266,8 +3428,14 @@
       <Width>250</Width>
     </PropertyDefn>
     <PropertyDefn>
-      <Name>naam</Name>
-      <ElementPath>naam</ElementPath>
+      <Name>naamNL</Name>
+      <ElementPath>naamNL</ElementPath>
+      <Type>String</Type>
+      <Width>250</Width>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>naamFries</Name>
+      <ElementPath>naamFries</ElementPath>
       <Type>String</Type>
       <Width>250</Width>
     </PropertyDefn>

--- a/top10nl/bin/top10-split.xsl
+++ b/top10nl/bin/top10-split.xsl
@@ -45,7 +45,7 @@ simpelweg doorgeggeven.
     </xsl:template>
 
     <!-- Copy extent van hele FeatureCollection -->
-     <xsl:template match="gml:boundedBy">
+    <xsl:template match="gml:boundedBy">
         <xsl:copy-of select="."/>
     </xsl:template>
 
@@ -65,13 +65,13 @@ simpelweg doorgeggeven.
 
     IsoHoogte  geometrieLijn    (OK)
     KadeOfWal  geometrieLijn    (OK)
-    Hoogteverschil   hogeZijde	(Lijn) Lijn lageZijde  (Lijn)
-    OverigRelief    geometrieLijn	 geometriePunt
+    Hoogteverschil   hogeZijde    (Lijn) Lijn lageZijde  (Lijn)
+    OverigRelief    geometrieLijn     geometriePunt
     HoogteOfDieptePunt  geometriePunt (OK)
     -->
     <xsl:template match="gml:featureMembers">
         <!-- START Multiple geom features: split into separate feature types, one for each geom type -->
-         <xsl:for-each select="top10nl:Waterdeel">
+        <xsl:for-each select="top10nl:Waterdeel">
             <xsl:call-template name="SplitsWaterdeel"/>
         </xsl:for-each>
 
@@ -84,42 +84,41 @@ simpelweg doorgeggeven.
         </xsl:for-each>
 
         <xsl:for-each select="top10nl:FunctioneelGebied">
-             <xsl:call-template name="SplitsFunctioneelGebied"/>
-         </xsl:for-each>
+            <xsl:call-template name="SplitsFunctioneelGebied"/>
+        </xsl:for-each>
 
         <xsl:for-each select="top10nl:GeografischGebied">
-             <xsl:call-template name="SplitsGeografischGebied"/>
-         </xsl:for-each>
+            <xsl:call-template name="SplitsGeografischGebied"/>
+        </xsl:for-each>
 
         <xsl:for-each select="top10nl:Inrichtingselement">
-              <xsl:call-template name="SplitsInrichtingselement"/>
-          </xsl:for-each>
-
+            <xsl:call-template name="SplitsInrichtingselement"/>
+        </xsl:for-each>
 
         <xsl:for-each select="top10nl:RegistratiefGebied">
-             <xsl:call-template name="SplitsRegistratiefGebied"/>
-         </xsl:for-each>
+            <xsl:call-template name="SplitsRegistratiefGebied"/>
+        </xsl:for-each>
 
         <xsl:for-each select="top10nl:OverigReliëf">
-                <xsl:call-template name="SplitsOverigRelief"/>
-            </xsl:for-each>
+            <xsl:call-template name="SplitsOverigRelief"/>
+        </xsl:for-each>
 
         <xsl:for-each select="top10nl:Hoogteverschil">
-               <xsl:call-template name="SplitsHoogteverschil"/>
-           </xsl:for-each>
+            <xsl:call-template name="SplitsHoogteverschil"/>
+        </xsl:for-each>
 
         <!-- START Single geom features: just copy all -->
         <xsl:for-each select="top10nl:Gebouw">
-             <xsl:call-template name="CopyAll">
-                 <xsl:with-param name="objectType">Gebouw_Vlak</xsl:with-param>
-             </xsl:call-template>
-         </xsl:for-each>
+            <xsl:call-template name="CopyAll">
+                <xsl:with-param name="objectType">Gebouw_Vlak</xsl:with-param>
+            </xsl:call-template>
+        </xsl:for-each>
 
-         <xsl:for-each select="top10nl:Terrein">
-             <xsl:call-template name="CopyAll">
-                 <xsl:with-param name="objectType">Terrein_Vlak</xsl:with-param>
-             </xsl:call-template>
-         </xsl:for-each>
+        <xsl:for-each select="top10nl:Terrein">
+            <xsl:call-template name="CopyAll">
+                <xsl:with-param name="objectType">Terrein_Vlak</xsl:with-param>
+            </xsl:call-template>
+        </xsl:for-each>
 
         <xsl:for-each select="top10nl:IsoHoogte">
             <xsl:call-template name="CopyAll">
@@ -134,116 +133,116 @@ simpelweg doorgeggeven.
         </xsl:for-each>
 
         <xsl:for-each select="top10nl:KadeOfWal">
-             <xsl:call-template name="CopyAll">
-                 <xsl:with-param name="objectType">KadeOfWal_Lijn</xsl:with-param>
-             </xsl:call-template>
-         </xsl:for-each>
+            <xsl:call-template name="CopyAll">
+                <xsl:with-param name="objectType">KadeOfWal_Lijn</xsl:with-param>
+            </xsl:call-template>
+        </xsl:for-each>
 
     </xsl:template>
 
-    <!--  Splits FunctioneelGebied heeft geometrieVlak en  abelPunt -->
+    <!-- Splits FunctioneelGebied: heeft geometrieVlak en labelPunt -->
     <xsl:template name="SplitsFunctioneelGebied">
-         <xsl:if test="top10nl:geometrieVlak != ''">
-             <xsl:call-template name="CopyWithSingleGeometry">
-                 <xsl:with-param name="objectType">FunctioneelGebied_Vlak</xsl:with-param>
-                 <xsl:with-param name="geometrie" select="top10nl:geometrieVlak"/>
-             </xsl:call-template>
-         </xsl:if>
+        <xsl:if test="top10nl:geometrieVlak != ''">
+            <xsl:call-template name="CopyWithSingleGeometry">
+                <xsl:with-param name="objectType">FunctioneelGebied_Vlak</xsl:with-param>
+                <xsl:with-param name="geometrie" select="top10nl:geometrieVlak"/>
+            </xsl:call-template>
+        </xsl:if>
 
-         <xsl:if test="top10nl:labelPunt != ''">
-             <xsl:call-template name="CopyWithSingleGeometry">
-                 <xsl:with-param name="objectType">FunctioneelGebied_Punt</xsl:with-param>
-                 <xsl:with-param name="geometrie" select="top10nl:labelPunt"/>
-             </xsl:call-template>
-         </xsl:if>
-     </xsl:template>
+        <xsl:if test="top10nl:labelPunt != ''">
+            <xsl:call-template name="CopyWithSingleGeometry">
+                <xsl:with-param name="objectType">FunctioneelGebied_Punt</xsl:with-param>
+                <xsl:with-param name="geometrie" select="top10nl:labelPunt"/>
+            </xsl:call-template>
+        </xsl:if>
+    </xsl:template>
 
-    <!--  Splits GeografischGebied heeft geometrieVlak en labelPunt -->
-     <xsl:template name="SplitsGeografischGebied">
-          <xsl:if test="top10nl:geometrieVlak != ''">
-              <xsl:call-template name="CopyWithSingleGeometry">
-                  <xsl:with-param name="objectType">GeografischGebied_Vlak</xsl:with-param>
-                  <xsl:with-param name="geometrie" select="top10nl:geometrieVlak"/>
-              </xsl:call-template>
-          </xsl:if>
+    <!-- Splits GeografischGebied: heeft geometrieVlak en labelPunt -->
+    <xsl:template name="SplitsGeografischGebied">
+        <xsl:if test="top10nl:geometrieVlak != ''">
+            <xsl:call-template name="CopyWithSingleGeometry">
+                <xsl:with-param name="objectType">GeografischGebied_Vlak</xsl:with-param>
+                <xsl:with-param name="geometrie" select="top10nl:geometrieVlak"/>
+            </xsl:call-template>
+        </xsl:if>
 
-          <xsl:if test="top10nl:labelPunt != ''">
-              <xsl:call-template name="CopyWithSingleGeometry">
-                  <xsl:with-param name="objectType">GeografischGebied_Punt</xsl:with-param>
-                  <xsl:with-param name="geometrie" select="top10nl:labelPunt"/>
-              </xsl:call-template>
-          </xsl:if>
-      </xsl:template>
+        <xsl:if test="top10nl:labelPunt != ''">
+            <xsl:call-template name="CopyWithSingleGeometry">
+                <xsl:with-param name="objectType">GeografischGebied_Punt</xsl:with-param>
+                <xsl:with-param name="geometrie" select="top10nl:labelPunt"/>
+            </xsl:call-template>
+        </xsl:if>
+    </xsl:template>
 
-    <!--  Splits Hoogteverschil heeft hogeZijde	(Lijn) en lageZijde (Lijn) -->
-      <xsl:template name="SplitsHoogteverschil">
-           <xsl:if test="top10nl:hogeZijde != ''">
-               <xsl:call-template name="CopyWithSingleGeometry">
-                   <xsl:with-param name="objectType">HoogteverschilHZ_Lijn</xsl:with-param>
-                   <xsl:with-param name="geometrie" select="top10nl:hogeZijde"/>
-               </xsl:call-template>
-           </xsl:if>
+    <!-- Splits Hoogteverschil: heeft hogeZijde    (Lijn) en lageZijde (Lijn) -->
+    <xsl:template name="SplitsHoogteverschil">
+        <xsl:if test="top10nl:hogeZijde != ''">
+            <xsl:call-template name="CopyWithSingleGeometry">
+                <xsl:with-param name="objectType">HoogteverschilHZ_Lijn</xsl:with-param>
+                <xsl:with-param name="geometrie" select="top10nl:hogeZijde"/>
+            </xsl:call-template>
+        </xsl:if>
 
-           <xsl:if test="top10nl:lageZijde != ''">
-               <xsl:call-template name="CopyWithSingleGeometry">
-                   <xsl:with-param name="objectType">HoogteverschilLZ_Lijn</xsl:with-param>
-                   <xsl:with-param name="geometrie" select="top10nl:lageZijde"/>
-               </xsl:call-template>
-           </xsl:if>
-       </xsl:template>
+        <xsl:if test="top10nl:lageZijde != ''">
+            <xsl:call-template name="CopyWithSingleGeometry">
+                <xsl:with-param name="objectType">HoogteverschilLZ_Lijn</xsl:with-param>
+                <xsl:with-param name="geometrie" select="top10nl:lageZijde"/>
+            </xsl:call-template>
+        </xsl:if>
+    </xsl:template>
 
-    <!--  Splits Inrichtingselement heeft geometrieLijn en geometriePunt -->
-     <xsl:template name="SplitsInrichtingselement">
-          <xsl:if test="top10nl:geometrieLijn != ''">
-              <xsl:call-template name="CopyWithSingleGeometry">
-                  <xsl:with-param name="objectType">Inrichtingselement_Lijn</xsl:with-param>
-                  <xsl:with-param name="geometrie" select="top10nl:geometrieLijn"/>
-              </xsl:call-template>
-          </xsl:if>
+    <!-- Splits Inrichtingselement: heeft geometrieLijn en geometriePunt -->
+    <xsl:template name="SplitsInrichtingselement">
+        <xsl:if test="top10nl:geometrieLijn != ''">
+            <xsl:call-template name="CopyWithSingleGeometry">
+                <xsl:with-param name="objectType">Inrichtingselement_Lijn</xsl:with-param>
+                <xsl:with-param name="geometrie" select="top10nl:geometrieLijn"/>
+            </xsl:call-template>
+        </xsl:if>
 
-          <xsl:if test="top10nl:geometriePunt != ''">
-              <xsl:call-template name="CopyWithSingleGeometry">
-                  <xsl:with-param name="objectType">Inrichtingselement_Punt</xsl:with-param>
-                  <xsl:with-param name="geometrie" select="top10nl:geometriePunt"/>
-              </xsl:call-template>
-          </xsl:if>
-      </xsl:template>
+        <xsl:if test="top10nl:geometriePunt != ''">
+            <xsl:call-template name="CopyWithSingleGeometry">
+                <xsl:with-param name="objectType">Inrichtingselement_Punt</xsl:with-param>
+                <xsl:with-param name="geometrie" select="top10nl:geometriePunt"/>
+            </xsl:call-template>
+        </xsl:if>
+    </xsl:template>
 
-    <!--  Splits OverigRelief heeft geometrieLijn en geometriePunt -->
-     <xsl:template name="SplitsOverigRelief">
-          <xsl:if test="top10nl:geometrieLijn != ''">
-              <xsl:call-template name="CopyWithSingleGeometry">
-                  <xsl:with-param name="objectType">OverigReliëf_Lijn</xsl:with-param>
-                  <xsl:with-param name="geometrie" select="top10nl:geometrieLijn"/>
-              </xsl:call-template>
-          </xsl:if>
+    <!-- Splits OverigRelief: heeft geometrieLijn en geometriePunt -->
+    <xsl:template name="SplitsOverigRelief">
+        <xsl:if test="top10nl:geometrieLijn != ''">
+            <xsl:call-template name="CopyWithSingleGeometry">
+                <xsl:with-param name="objectType">OverigReliëf_Lijn</xsl:with-param>
+                <xsl:with-param name="geometrie" select="top10nl:geometrieLijn"/>
+            </xsl:call-template>
+        </xsl:if>
 
-          <xsl:if test="top10nl:geometriePunt != ''">
-              <xsl:call-template name="CopyWithSingleGeometry">
-                  <xsl:with-param name="objectType">OverigReliëf_Punt</xsl:with-param>
-                  <xsl:with-param name="geometrie" select="top10nl:geometriePunt"/>
-              </xsl:call-template>
-          </xsl:if>
-      </xsl:template>
+        <xsl:if test="top10nl:geometriePunt != ''">
+            <xsl:call-template name="CopyWithSingleGeometry">
+                <xsl:with-param name="objectType">OverigReliëf_Punt</xsl:with-param>
+                <xsl:with-param name="geometrie" select="top10nl:geometriePunt"/>
+            </xsl:call-template>
+        </xsl:if>
+    </xsl:template>
 
-    <!--  Splits GeografischGebied heeft geometrieVlak en labelPunt -->
-     <xsl:template name="SplitsRegistratiefGebied">
-          <xsl:if test="top10nl:geometrieVlak != ''">
-              <xsl:call-template name="CopyWithSingleGeometry">
-                  <xsl:with-param name="objectType">RegistratiefGebied_Vlak</xsl:with-param>
-                  <xsl:with-param name="geometrie" select="top10nl:geometrieVlak"/>
-              </xsl:call-template>
-          </xsl:if>
+    <!-- Splits GeografischGebied: heeft geometrieVlak en labelPunt -->
+    <xsl:template name="SplitsRegistratiefGebied">
+        <xsl:if test="top10nl:geometrieVlak != ''">
+            <xsl:call-template name="CopyWithSingleGeometry">
+                <xsl:with-param name="objectType">RegistratiefGebied_Vlak</xsl:with-param>
+                <xsl:with-param name="geometrie" select="top10nl:geometrieVlak"/>
+            </xsl:call-template>
+        </xsl:if>
 
-          <xsl:if test="top10nl:labelPunt != ''">
-              <xsl:call-template name="CopyWithSingleGeometry">
-                  <xsl:with-param name="objectType">RegistratiefGebied_Punt</xsl:with-param>
-                  <xsl:with-param name="geometrie" select="top10nl:labelPunt"/>
-              </xsl:call-template>
-          </xsl:if>
-      </xsl:template>
-    
-    <!-- Spoorbaandeel geometrieLijn geometriePunt -->
+        <xsl:if test="top10nl:labelPunt != ''">
+            <xsl:call-template name="CopyWithSingleGeometry">
+                <xsl:with-param name="objectType">RegistratiefGebied_Punt</xsl:with-param>
+                <xsl:with-param name="geometrie" select="top10nl:labelPunt"/>
+            </xsl:call-template>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- Splits Spoorbaandeel: heeft geometrieLijn en geometriePunt -->
     <xsl:template name="SplitsSpoorbaandeel">
         <xsl:if test="top10nl:geometriePunt != ''">
             <xsl:call-template name="CopyWithSingleGeometry">
@@ -261,7 +260,7 @@ simpelweg doorgeggeven.
 
     </xsl:template>
 
-    <!-- Waterdeel geometrieVlak geometrieLijn  geometriePunt -->
+    <!-- Splits Waterdeel: heeft geometrieVlak, geometrieLijn en geometriePunt -->
     <xsl:template name="SplitsWaterdeel">
         <xsl:if test="top10nl:geometrieVlak != ''">
             <xsl:call-template name="CopyWithSingleGeometry">
@@ -286,7 +285,7 @@ simpelweg doorgeggeven.
 
     </xsl:template>
 
-    <!-- Wegdeel geometrieVlak geometrieLijn geometriePunt hartLijn hartPunt -->
+    <!-- Splits Wegdeel, heeft geometrieVlak, geometrieLijn, geometriePunt, hartLijn en hartPunt -->
     <xsl:template name="SplitsWegdeel">
         <xsl:if test="top10nl:geometrieVlak != ''">
             <xsl:call-template name="CopyWithSingleGeometry">
@@ -319,7 +318,7 @@ simpelweg doorgeggeven.
 
         <xsl:if test="top10nl:hartPunt != ''">
             <xsl:call-template name="CopyWithSingleGeometry">
-                <xsl:with-param name="objectType" >Wegdeel_HartPunt</xsl:with-param>
+                <xsl:with-param name="objectType">Wegdeel_HartPunt</xsl:with-param>
                 <xsl:with-param name="geometrie" select="top10nl:hartPunt"/>
             </xsl:call-template>
         </xsl:if>
@@ -332,11 +331,36 @@ simpelweg doorgeggeven.
             <xsl:value-of select='substring(nen3610:identificatie, 12,19)'/>
         </fid>
         <!-- Copieer alle nen3610:* attributen. -->
-         <xsl:copy-of select="nen3610:*"/>
+        <xsl:copy-of select="nen3610:*"/>
 
-        <!-- Copieer alle top10:* attributen  behalve de geometrieen. -->
+        <!-- Splits namen en straatnamen uit in Nederlands en Fries -->
+        <xsl:for-each select="top10nl:naam[@xml:lang='nl']">
+            <naamNL>
+                <xsl:value-of select="text()"/>
+            </naamNL>
+        </xsl:for-each>
+
+        <xsl:for-each select="top10nl:naam[@xml:lang='fy']">
+            <naamFries>
+                <xsl:value-of select="text()"/>
+            </naamFries>
+        </xsl:for-each>
+
+        <xsl:for-each select="top10nl:straatnaam[@xml:lang='nl']">
+            <straatnaamNL>
+                <xsl:value-of select="text()"/>
+            </straatnaamNL>
+        </xsl:for-each>
+
+        <xsl:for-each select="top10nl:straatnaam[@xml:lang='fy']">
+            <straatnaamFries>
+                <xsl:value-of select="text()"/>
+            </straatnaamFries>
+        </xsl:for-each>
+
+        <!-- Copieer alle top10:* attributen, behalve de geometrieen en de namen. -->
         <xsl:copy-of
-                select="top10nl:*[not(self::top10nl:geometrieVlak)][not(self::top10nl:geometrieLijn)][not(self::top10nl:geometriePunt)][not(self::top10nl:hartLijn)][not(self::top10nl:hartPunt)][not(self::top10nl:hogeZijde)][not(self::top10nl:lageZijde)]"/>
+                select="top10nl:*[not(self::top10nl:geometrieVlak)][not(self::top10nl:geometrieLijn)][not(self::top10nl:geometriePunt)][not(self::top10nl:hartLijn)][not(self::top10nl:hartPunt)][not(self::top10nl:hogeZijde)][not(self::top10nl:lageZijde)][not(self::top10nl:naam)][not(self::top10nl:straatnaam)]"/>
     </xsl:template>
 
     <!-- Copieer alle elementen van object behalve geometrieen en voeg 1 enkele geometrie aan eind toe. -->
@@ -356,10 +380,11 @@ simpelweg doorgeggeven.
         <xsl:param name="objectType"/>
         <gml:featureMember>
             <xsl:element name="{$objectType}">
-                <fid>
-                    <xsl:value-of select='substring(nen3610:identificatie, 12,19)'/>
-                </fid>
-                <xsl:copy-of select="*"/>
+                <!-- Kopieer alle niet-geometrie properties -->
+                <xsl:call-template name="CopyNonGeoProps"/>
+                
+                <!-- Kopieer geometrie property -->
+                <xsl:copy-of select="top10nl:geometrieVlak|top10nl:geometrieLijn|top10nl:geometriePunt"/>
             </xsl:element>
         </gml:featureMember>
     </xsl:template>

--- a/top10nl/test/data/test.gml
+++ b/top10nl/test/data/test.gml
@@ -537,7 +537,10 @@
             <nen3610:versieBeginTijd>2011-08-25T00:00:00</nen3610:versieBeginTijd>
 
 
-            <top10nl:naam xml:lang="nl">Veere</top10nl:naam>
+            <!-- NB: in Top10NL data is de Nederlandse naam gelijk aan de Friese naam, maar voor de test is het onderscheid belangrijk -->
+            <top10nl:naam xml:lang="nl">Tietjerksteradeel</top10nl:naam>
+            <top10nl:naam xml:lang="fy">Tytsjerksteradiel</top10nl:naam>
+
 
 
             <top10nl:typeRegistratiefGebied>gemeente


### PR DESCRIPTION
Per versie 1.1.1 van Top10NL worden namen en straatnamen opgedeeld in resp. de attributen naamNL/naamFries en straatnaamNL/straatnaamFries. Deze oplossing pas ik vast toe in de XSL/GFS voor Top10NL. Zie ook issue #17.
