### PR TITLE
Debug-print regel verwijderd

### DIFF
--- a/top10nl/bin/top10-trans.py
+++ b/top10nl/bin/top10-trans.py
@@ -41,7 +41,6 @@ def transform(gml_file, xslt_file, out_dir, max_features = MAX_FEATURES):
     features = []
     for elem in gmlDoc.getroot():
         tag = elem.tag.rsplit('}', 1)[-1]
-        print tag
         if tag=='featureMembers' or tag=='featureMember':
             features.extend(list(elem))
         gmlDoc.getroot().remove(elem)


### PR DESCRIPTION
Zorgde voor nogal wat spam bij de output van het 1.1.1 testbestand. Bij 1.0 worden maar 2 extra regels gelogd, maar bij 1.1.1 voor elk feature.
