### PR TITLE
Sorteren bestandsnamen uit zip's en directories

### DIFF
--- a/bag/src/bagfilereader.py
+++ b/bag/src/bagfilereader.py
@@ -83,7 +83,7 @@ class BAGFileReader:
 
         tzip = self.zip
         namelist = sorted(tzip.namelist())
-        Log.log.info("readzipfile content=" + str(list))
+        Log.log.info("readzipfile content=" + str(namelist))
         for naam in namelist:
             ext = naam.split('.')
             Log.log.info("readzipfile: " + naam)


### PR DESCRIPTION
Ik had bij een initiële import vanuit een Kadaster levering het probleem dat een bestand als '9999NUM08092012-000001.xml' als laatste werd ingelezen in plaats van als eerste. 

Deze patch zorgt er voor dat lijsten van bestandsnamen altijd gesorteerd zijn.
