### PR TITLE
Wijziging SQL UPDATE query voor mutaties

### DIFF
--- a/bag/src/bagobject.py
+++ b/bag/src/bagobject.py
@@ -174,22 +174,13 @@ class BAGObject:
 
         # UPDATE weather SET temp_lo = temp_lo+1, temp_hi = temp_lo+15, prcp = DEFAULT
         # WHERE city = 'San Francisco' AND date = '2003-07-03';
-        # Unieke key is combined (identificatie,aanduidingRecordInactief,aanduidingrecordcorrectie,einddatumTijdvakGeldigheid)
-        where = "WHERE identificatie = %s AND aanduidingrecordinactief = %s AND aanduidingrecordcorrectie = %s AND einddatumTijdvakGeldigheid "
-        eindDatum = self.origineelObj.attribuut('einddatumTijdvakGeldigheid').waardeSQL()
-
-        # Tricky: indien eindDatum leeg moet in WHERE "is NULL" staan
-        # want "= NULL" geeft geen resultaat
-        # http://stackoverflow.com/questions/4476172/postgresql-select-where-timestamp-is-empty
-        if eindDatum:
-            where += "= %s"
-        else:
-            where += "is %s"
+        # Unieke key is combined (identificatie,aanduidingRecordInactief,aanduidingrecordcorrectie,begindatumTijdvakGeldigheid)
+        where = "WHERE identificatie = %s AND aanduidingrecordinactief = %s AND aanduidingrecordcorrectie = %s AND begindatumTijdvakGeldigheid = %s "
 
         self.inhoud.extend((self.origineelObj.attribuut('identificatie').waardeSQL(),
                              self.origineelObj.attribuut('aanduidingRecordInactief').waardeSQL(),
                              self.origineelObj.attribuut('aanduidingRecordCorrectie').waardeSQL(),
-                             eindDatum))
+                             self.origineelObj.attribuut('begindatumTijdvakGeldigheid').waardeSQL() ))
 
         self.sql = "UPDATE " + self.naam() + " SET " + nameVals + " " + where
 


### PR DESCRIPTION
Bij mij werkte de import van mutaties niet goed. Wat er gebeurde bij bijwerken bestaande BAG objecten:

* Nieuwe versie van BAG-object werd toegevoegd (met uiteraard einddatum = NULL)
* Bestaande versie van BAG-object werd gewijzigd met een nieuwe einddatum. 

Dat laatste ging niet goed, omdat de update query zocht naar BAG-record met einddatum = NULL (namelijk de oude versie van een BAG-object) en daarmee werden twee BAG-records bijgewerkt:
* De net nieuwe toegevoegde
* De oorspronkelijke

Ik heb dit gewijzigd: de update query kijkt nu naar begindatum ipv einddatum. BAG identificatie, begindatum (en aanduiding record actief  en aanduidingrecordcorrectie) vormen een unieke key.

Mocht er behoefte zijn aan een eenvoudige testcase, laat maar weten.