### PR TITLE
Twee kleine fixes i.v.m. python 3 als standaard op mijn systeem

### DIFF
--- a/bag/bin/bag-extract.sh
+++ b/bag/bin/bag-extract.sh
@@ -17,4 +17,10 @@ BASEDIR=`(cd "$BASEDIR"; pwd)`
 PY_SCRIPT=$BASEDIR/src/bagextract.py
 
 # uitvoeren Python script met alle meegegeven args
-python $PY_SCRIPT $@
+ret=`python -c 'import sys; print("%i" % (sys.hexversion<0x03000000))'`
+if [ $ret -eq 0 ]; then
+    #Python 3 is de standaard, roep python2 aan.
+    python2 $PY_SCRIPT $@
+else
+    python $PY_SCRIPT $@
+fi

--- a/bag/src/bagextract.py
+++ b/bag/src/bagextract.py
@@ -58,7 +58,7 @@ def confirm(prompt=None, resp=False):
         if not ans:
             return resp
         if ans not in ['j', 'J', 'n', 'N']:
-            print 'Geef j of n.'
+            print ('Geef j of n.')
             continue
         if ans == 'j' or ans == 'J':
             return True


### PR DESCRIPTION
Ik heb twee kleine fixes uitgevoerd. Allereerst een print commando python3 compatibel gemaakt. Toen ik daarna nog meer problemen tegen kwam tijdens het uitvoeren van runtest.sh heb ik bag-extract.sh aangepast zodat wordt gecontroleerd welke python versie je draait en op basis daarvan de juiste python executable wordt gebruikt.