### PR TITLE
Update gemeentecode & naam voor 'De Fryske Marren' (1940).

### DIFF
--- a/bag/db/data/cbs-gemeentenperprovincie-2015.csv
+++ b/bag/db/data/cbs-gemeentenperprovincie-2015.csv
@@ -29,7 +29,7 @@ Gemcode;Gemcodel;provcode;provcodel
 0058;Dongeradeel;21;Friesland
 1722;Ferwerderadiel;21;Friesland
 0070;Franekeradeel;21;Friesland
-1921;De Friese Meren;21;Friesland
+1940;De Fryske Marren;21;Friesland
 0072;Harlingen;21;Friesland
 0074;Heerenveen;21;Friesland
 0079;Kollumerland en Nieuwkruisland;21;Friesland


### PR DESCRIPTION
Was 'De Friese Meren' (1921) tot 2015-07-01.

N.a.v. de [BAG Friese Meren?](https://groups.google.com/d/msg/nlextract/jlDKCYdL6ZU/jakfwcSJBwAJ) discussie op de mailinglist.