### PR TITLE
BAG relatietabellen geschikt gemaakt voor *actueelbestaand-views

### DIFF
--- a/bag/db/script/bag-db.sql
+++ b/bag/db/script/bag-db.sql
@@ -254,6 +254,8 @@ CREATE TABLE verblijfsobjectpand (
   aanduidingRecordCorrectie INTEGER,
   begindatumTijdvakGeldigheid TIMESTAMP WITHOUT TIME ZONE,
   einddatumTijdvakGeldigheid TIMESTAMP WITHOUT TIME ZONE,
+  verblijfsobjectStatus verblijfsobjectStatus,
+  geom_valid BOOLEAN,
   gerelateerdpand NUMERIC(16),
   PRIMARY KEY (gid)
 );
@@ -268,6 +270,10 @@ CREATE TABLE adresseerbaarobjectnevenadres (
   aanduidingRecordCorrectie INTEGER,
   begindatumTijdvakGeldigheid TIMESTAMP WITHOUT TIME ZONE,
   einddatumTijdvakGeldigheid TIMESTAMP WITHOUT TIME ZONE,
+  ligplaatsStatus ligplaatsStatus,
+  standplaatsStatus standplaatsStatus,
+  verblijfsobjectStatus verblijfsobjectStatus,
+  geom_valid BOOLEAN,
   nevenadres NUMERIC(16),
   PRIMARY KEY (gid)
 );
@@ -286,6 +292,8 @@ CREATE TABLE verblijfsobjectgebruiksdoel (
   aanduidingrecordcorrectie integer,
   begindatumtijdvakgeldigheid timestamp without time zone,
   einddatumTijdvakGeldigheid TIMESTAMP WITHOUT TIME ZONE,
+  verblijfsobjectStatus verblijfsobjectStatus,
+  geom_valid BOOLEAN,
   gebruiksdoelverblijfsobject gebruiksdoelVerblijfsobject,
   PRIMARY KEY (gid)
 );

--- a/bag/db/script/bag-view-actueel-bestaand.sql
+++ b/bag/db/script/bag-view-actueel-bestaand.sql
@@ -293,7 +293,7 @@ CREATE VIEW verblijfsobjectactueelbestaand AS
       AND verblijfsobject.aanduidingrecordinactief = FALSE
       AND (verblijfsobject.geom_valid is NULL OR verblijfsobject.geom_valid = TRUE)
       AND (verblijfsobject.verblijfsobjectstatus <> 'Niet gerealiseerd verblijfsobject'
-      AND verblijfsobject.verblijfsobjectstatus  <> 'Verblijfsobject ingetrokken');
+        AND verblijfsobject.verblijfsobjectstatus  <> 'Verblijfsobject ingetrokken');
 
 -- JvdB removed AND verblijfsobject.verblijfsobjectstatus  <> 'Verblijfsobject gevormd', see issue #173
 -- https://github.com/opengeogroep/NLExtract/issues/173  23.3.16
@@ -352,12 +352,36 @@ CREATE VIEW verblijfsobjectpandactueel AS
             vbop.aanduidingrecordcorrectie,
             vbop.begindatumtijdvakgeldigheid,
             vbop.einddatumtijdvakgeldigheid,
-            vbop.gerelateerdpand
+            vbop.gerelateerdpand,
+            vbop.verblijfsobjectstatus,
+            vbop.geom_valid
     FROM verblijfsobjectpand as vbop
   WHERE
     vbop.begindatumtijdvakgeldigheid <= LOCALTIMESTAMP
     AND (vbop.einddatumtijdvakgeldigheid is NULL OR vbop.einddatumtijdvakgeldigheid >= LOCALTIMESTAMP)
-    AND vbop.aanduidingrecordinactief = FALSE;
+    AND vbop.aanduidingrecordinactief = FALSE
+    AND (vbop.geom_valid is NULL OR vbop.geom_valid = TRUE);
+
+DROP VIEW IF EXISTS verblijfsobjectpandactueelbestaand;
+CREATE VIEW verblijfsobjectpandactueelbestaand AS
+    SELECT vbop.gid,
+            vbop.identificatie,
+            vbop.aanduidingrecordinactief,
+            vbop.aanduidingrecordcorrectie,
+            vbop.begindatumtijdvakgeldigheid,
+            vbop.einddatumtijdvakgeldigheid,
+            vbop.gerelateerdpand,
+            vbop.verblijfsobjectstatus,
+            vbop.geom_valid
+    FROM verblijfsobjectpand as vbop
+  WHERE
+    vbop.begindatumtijdvakgeldigheid <= LOCALTIMESTAMP
+    AND (vbop.einddatumtijdvakgeldigheid is NULL OR vbop.einddatumtijdvakgeldigheid >= LOCALTIMESTAMP)
+    AND vbop.aanduidingrecordinactief = FALSE
+    AND (vbop.geom_valid is NULL OR vbop.geom_valid = TRUE)
+    AND ((vbop.verblijfsobjectstatus <> 'Niet gerealiseerd verblijfsobject' AND
+          vbop.verblijfsobjectstatus <> 'Verblijfsobject ingetrokken') OR
+         vbop.verblijfsobjectstatus is NULL);
 
 DROP VIEW IF EXISTS adresseerbaarobjectnevenadresactueel;
 CREATE VIEW adresseerbaarobjectnevenadresactueel AS
@@ -367,12 +391,42 @@ CREATE VIEW adresseerbaarobjectnevenadresactueel AS
             aon.aanduidingrecordcorrectie,
             aon.begindatumtijdvakgeldigheid,
             aon.einddatumtijdvakgeldigheid,
-            aon.nevenadres
+            aon.nevenadres,
+            aon.ligplaatsstatus,
+            aon.standplaatsstatus,
+            aon.verblijfsobjectstatus,
+            aon.geom_valid
     FROM adresseerbaarobjectnevenadres as aon
   WHERE
     aon.begindatumtijdvakgeldigheid <= LOCALTIMESTAMP
     AND (aon.einddatumtijdvakgeldigheid is NULL OR aon.einddatumtijdvakgeldigheid >= LOCALTIMESTAMP)
-    AND aon.aanduidingrecordinactief = FALSE;
+    AND aon.aanduidingrecordinactief = FALSE
+    AND (aon.geom_valid is NULL OR aon.geom_valid = TRUE);
+
+DROP VIEW IF EXISTS adresseerbaarobjectnevenadresactueelbestaand;
+CREATE VIEW adresseerbaarobjectnevenadresactueelbestaand AS
+    SELECT aon.gid,
+            aon.identificatie,
+            aon.aanduidingrecordinactief,
+            aon.aanduidingrecordcorrectie,
+            aon.begindatumtijdvakgeldigheid,
+            aon.einddatumtijdvakgeldigheid,
+            aon.nevenadres,
+            aon.ligplaatsstatus,
+            aon.standplaatsstatus,
+            aon.verblijfsobjectstatus,
+            aon.geom_valid
+    FROM adresseerbaarobjectnevenadres as aon
+  WHERE
+    aon.begindatumtijdvakgeldigheid <= LOCALTIMESTAMP
+    AND (aon.einddatumtijdvakgeldigheid is NULL OR aon.einddatumtijdvakgeldigheid >= LOCALTIMESTAMP)
+    AND aon.aanduidingrecordinactief = FALSE
+    AND (aon.geom_valid is NULL OR aon.geom_valid = TRUE)
+    AND ((aon.ligplaatsstatus <> 'Plaats ingetrokken' OR aon.ligplaatsstatus is NULL) AND
+         (aon.standplaatsstatus <> 'Plaats ingetrokken' OR aon.standplaatsstatus is NULL) AND
+         ((aon.verblijfsobjectstatus <> 'Niet gerealiseerd verblijfsobject' AND
+           aon.verblijfsobjectstatus <> 'Verblijfsobject ingetrokken') OR
+          aon.verblijfsobjectstatus is NULL));
 
 DROP VIEW IF EXISTS verblijfsobjectgebruiksdoelactueel;
 CREATE VIEW verblijfsobjectgebruiksdoelactueel AS
@@ -382,12 +436,36 @@ CREATE VIEW verblijfsobjectgebruiksdoelactueel AS
             vog.aanduidingrecordcorrectie,
             vog.begindatumtijdvakgeldigheid,
             vog.einddatumtijdvakgeldigheid,
-            vog.gebruiksdoelverblijfsobject
+            vog.gebruiksdoelverblijfsobject,
+            vog.verblijfsobjectstatus,
+            vog.geom_valid
     FROM verblijfsobjectgebruiksdoel as vog
   WHERE
     vog.begindatumtijdvakgeldigheid <= LOCALTIMESTAMP
     AND (vog.einddatumtijdvakgeldigheid is NULL OR vog.einddatumtijdvakgeldigheid >= LOCALTIMESTAMP)
-    AND vog.aanduidingrecordinactief = FALSE;
+    AND vog.aanduidingrecordinactief = FALSE
+    AND (vog.geom_valid is NULL OR vog.geom_valid = TRUE);
+
+DROP VIEW IF EXISTS verblijfsobjectgebruiksdoelactueelbestaand;
+CREATE VIEW verblijfsobjectgebruiksdoelactueelbestaand AS
+    SELECT vog.gid,
+            vog.identificatie,
+            vog.aanduidingrecordinactief,
+            vog.aanduidingrecordcorrectie,
+            vog.begindatumtijdvakgeldigheid,
+            vog.einddatumtijdvakgeldigheid,
+            vog.gebruiksdoelverblijfsobject,
+            vog.verblijfsobjectstatus,
+            vog.geom_valid
+    FROM verblijfsobjectgebruiksdoel as vog
+  WHERE
+    vog.begindatumtijdvakgeldigheid <= LOCALTIMESTAMP
+    AND (vog.einddatumtijdvakgeldigheid is NULL OR vog.einddatumtijdvakgeldigheid >= LOCALTIMESTAMP)
+    AND vog.aanduidingrecordinactief = FALSE
+    AND (vog.geom_valid is NULL OR vog.geom_valid = TRUE)
+    AND ((vog.verblijfsobjectstatus <> 'Niet gerealiseerd verblijfsobject' AND
+          vog.verblijfsobjectstatus <> 'Verblijfsobject ingetrokken') OR
+         vog.verblijfsobjectstatus is NULL);
 
 DROP VIEW IF EXISTS gemeente_woonplaatsactueelbestaand;
 CREATE VIEW gemeente_woonplaatsactueelbestaand AS

--- a/bag/src/bagobject.py
+++ b/bag/src/bagobject.py
@@ -138,6 +138,10 @@ class BAGObject:
         sql += " identificatie FROM " + self.naam() + "actueelbestaand"
         sql += " WHERE identificatie = " + str(self.attribuut('identificatie').waarde())
         return sql
+        
+    # Retourneer boolean waarde of het attribuut bestaat
+    def heeftAttribuut(self, naam):
+        return naam in self.attributen
 
     # Retourneer het attribuut met de gegeven naam
     def attribuut(self, naam):
@@ -344,7 +348,8 @@ class BAGadresseerbaarObject(BAGObject):
                                        "bag_LVC:gerelateerdeAdressen/bag_LVC:hoofdadres/bag_LVC:identificatie"))
         self.relaties.append(BAGrelatieAttribuut(self, "adresseerbaarobjectnevenadres",
                                               16, "nevenadres",
-                                              "bag_LVC:gerelateerdeAdressen/bag_LVC:nevenadres/bag_LVC:identificatie"))
+                                              "bag_LVC:gerelateerdeAdressen/bag_LVC:nevenadres/bag_LVC:identificatie",
+                                              ["ligplaatsStatus", "standplaatsStatus", "verblijfsobjectStatus", "geom_valid"]))
 
 #--------------------------------------------------------------------------------------------------------
 # Class         Ligplaats
@@ -398,7 +403,7 @@ class Verblijfsobject(BAGadresseerbaarObject):
     def __init__(self):
 
         BAGadresseerbaarObject.__init__(self, "bag_LVC:Verblijfsobject", "verblijfsobject", "VBO")
-        self.voegToe(BAGenumAttribuut(Verblijfsobject.statusEnum,"verblijfsobjectStatus",
+        self.voegToe(BAGenumAttribuut(Verblijfsobject.statusEnum, "verblijfsobjectStatus",
                                         "bag_LVC:verblijfsobjectStatus"))
         self.voegToe(BAGnumeriekAttribuut(6, "oppervlakteVerblijfsobject",
                                         "bag_LVC:oppervlakteVerblijfsobject"))
@@ -411,11 +416,14 @@ class Verblijfsobject(BAGadresseerbaarObject):
         self.voegToe(BAGgeometrieValidatie("geom_valid", "geovlak"))
 
         self.relaties.append(BAGenumRelatieAttribuut(self, "verblijfsobjectgebruiksdoel",
-                                                               "gebruiksdoelVerblijfsobject",
-                                                               "bag_LVC:gebruiksdoelVerblijfsobject", Verblijfsobject.gebruiksdoelEnum))
+                                                           "gebruiksdoelVerblijfsobject",
+                                                           "bag_LVC:gebruiksdoelVerblijfsobject",
+                                                           ["verblijfsobjectStatus", "geom_valid"],
+                                                           Verblijfsobject.gebruiksdoelEnum))
         self.relaties.append(BAGrelatieAttribuut(self, "verblijfsobjectpand",
-                                                   16, "gerelateerdPand",
-                                                   "bag_LVC:gerelateerdPand/bag_LVC:identificatie"))
+                                                       16, "gerelateerdPand",
+                                                       "bag_LVC:gerelateerdPand/bag_LVC:identificatie",
+                                                       ["verblijfsobjectStatus", "geom_valid"]))
 
     def heeftGeometrie(self):
         return True
@@ -603,7 +611,7 @@ class VerblijfsObjectPand(BAGRelatie):
 
 #--------------------------------------------------------------------------------------------------------
 # Class         AdresseerbaarObjectNevenAdres
-# Omschrijving  Relatie van Verblijfsobject naar Nevenadres
+# Omschrijving  Relatie van Ligplaats, Standplaats of Verblijfsobject naar Nevenadres
 #--------------------------------------------------------------------------------------------------------
 class AdresseerbaarObjectNevenAdres(BAGRelatie):
     def __init__(self):


### PR DESCRIPTION
Deze views zijn ook toegevoegd. Op deze manier zouden er bij het joinen van de relatietabellen met andere tabellen (bijv. pand) minder dubbelingen op moeten treden. Zie issue #146 voor meer informatie. Dit pull request is een alternatief voor pull request #148.

Om de *actueelbestaand-views te genereren, zijn er twee werkwijzen mogelijk. De eerste manier is het joinen van de views met verblijfsobject en de tweede manier is het toevoegen van meer informatie over de verblijfsobjecten, nl. status en geom_valid, zodat de actueelbestaand-views op dezelfde manier als bij verblijfsobjecten gemaakt kunnen worden. Bij het maken van de views d.m.v. het joinen met verblijfsobjecten was de verwachting dat dit zwaar ten koste zou gaan van de performance. Dit bleek ook zo het geval te zijn. Dus het uitbreiden van de relatietabellen met extra kolommen was de enige overgebleven manier.

Dat het uitbreiden van de relatietabellen ook de juiste weg is, bewijst het feit dat adresseerbaarobjectnevenadres niet alleen voor verblijfsobject bestemd is, maar ook voor ligplaats en standplaats. Vanwege deze reden zijn ook ligplaatsstatus en standplaatsstatus aan adresseerbaarobjectnevenadres toegevoegd. Verblijfsobjectgebruiksdoel en verblijfsobjectpand hebben alleen de kolommen verblijfsobjectstatus en geom_valid erbij gekregen.

Uitleg per source file:

- bag/db/script/bag-db.sql: hier worden de nieuwe kolommen gedefinieerd.
- bag/db/script/bag-view-actueelbestaand:
  - de *actueel-views zijn aangepast, want de nieuwe kolommen moeten ook getoond worden en ook moet hier al worden gefilterd op geom_valid. Beide wijzigingen zijn conform de andere views.
  - de *actueelbestaand-views zijn nieuw, conform de reeds bestaande views.
- bag/src/bagattribuut.py: aan de klasse BAGrelatieAttribuut heb ik een extra constructor-parameter extraAttributes toegevoegd. Dit bevat een lijst met attributen die vanaf het parent object overgenomen moeten worden. De methods maakInsertSQL en maakCopySQL heb ik aangepast, om gebruik te maken van de extra attributen. In sommige gevallen betekent dit dat ik eerst lijsten ga maken van attribuutnamen of -waarden, omdat er op sommige plekken tuples verwacht worden. Die zijn immers niet aanpasbaar. De nieuwe parameter is ook aan de constructor van BAGenumRelatieAttribuut toegevoegd.
- bag/src/bagobject.py: aan BAGObject is de method heeftAttribuut toegevoegd. Dit is gedaan zodat de aanroepende functie een KeyError bij de aanroep van de method attribuut kan voorkomen. Tevens zijn bij het toevoegen van de relatietabellen de extra attributen gedefinieerd.